### PR TITLE
Alias imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,22 @@ Then navigate to the project:
 
 That will start a development server at [http://localhost:8000](http://localhost:8000).
 
-## Documentation
+## Alias Imports
 
-TBD ...
+This project support alias imports through [the gatsby-alias-imports plugin](https://www.gatsbyjs.org/packages/gatsby-alias-imports/). This provides a means for being able to import components without needing to know exactly where you are in the tree. It can make moving items around a little less painful.
+
+The convention is as follows:
+
+- Aliases to project-specific files should be prepended with a `~` character.
+- Aliases to plugins can treat them as though they are packages.
+
+Unfortunately, for seamless integration across the board, we have to configure aliases for every place in which we're going to use them, which means _at least_ Gatsby, VS Code, and Jest. Therefore, they are replicated (with the appropriate syntax) in:
+
+- `gatsby-config.js`
+- `jest.config.js`
+- `jsconfig.json`
+
+If you wish to add an alias to your project, make sure to touch all appropriate config files.
 
 ## Linters
 
@@ -31,4 +44,4 @@ Run `yarn run lint` to ensure there are no linter errors or warnings before comm
 
 ## License
 
-This project is distributed under the [MIT License](LICENSE.md).
+gatsby-starter-ample is distributed under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ That will start a development server at [http://localhost:8000](http://localhost
 
 This project support alias imports through [the gatsby-alias-imports plugin](https://www.gatsbyjs.org/packages/gatsby-alias-imports/). This provides a means for being able to import components without needing to know exactly where you are in the tree. It can make moving items around a little less painful.
 
-The convention is as follows:
+The convention is to treat directories in our project like [NPM scopes](https://docs.npmjs.com/about-scopes). The scope is prepended with a `@` character. There are three prefixes supported out of the box:
 
-- Aliases to project-specific files should be prepended with a `~` character.
-- Aliases to plugins can treat them as though they are packages.
+- `@plugins` maps to `./plugins`
+- `@root` maps to `./`
+- `@src` maps to `./src`
 
 Unfortunately, for seamless integration across the board, we have to configure aliases for every place in which we're going to use them, which means _at least_ Gatsby, VS Code, and Jest. Therefore, they are replicated (with the appropriate syntax) in:
 
@@ -29,7 +30,7 @@ Unfortunately, for seamless integration across the board, we have to configure a
 - `jest.config.js`
 - `jsconfig.json`
 
-If you wish to add an alias to your project, make sure to touch all appropriate config files.
+If you wish to add a custom alias to your project, make sure to touch all appropriate config files.
 
 ## Linters
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,12 +16,9 @@ module.exports = {
       resolve: `gatsby-alias-imports`,
       options: {
         aliases: {
-          "~components": `./src/components`,
-          "~layout": `./src/layout`,
-          "~root": `./`,
-          "~templates": `./src/templates`,
-          "gatsby-ample-debuggers": "./plugins/gatsby-ample-debuggers",
-          "gatsby-ample-seo": "./plugins/gatsby-ample-seo"
+          "@plugins": `./plugins`,
+          "@root": `./`,
+          "@src": `./src`
         }
       }
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,9 +16,12 @@ module.exports = {
       resolve: `gatsby-alias-imports`,
       options: {
         aliases: {
-          components: `./src/components`,
-          templates: `./src/templates`,
-          root: `./`
+          "~components": `./src/components`,
+          "~layout": `./src/layout`,
+          "~root": `./`,
+          "~templates": `./src/templates`,
+          "gatsby-ample-debuggers": "./plugins/gatsby-ample-debuggers",
+          "gatsby-ample-seo": "./plugins/gatsby-ample-seo"
         }
       }
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,12 +5,9 @@ module.exports = {
   moduleNameMapper: {
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,
-    "\\~components\\/(.*)$": `<rootDir>/src/components/$1`,
-    "\\~layout(.*)$": `<rootDir>/src/layout$1`,
-    "\\~root\\/(.*)$": `<rootDir>/$1`,
-    "\\~templates\\/(.*)$": `<rootDir>/src/templates/$1`,
-    "^gatsby-ample-debuggers(.*)$": `<rootDir>/plugins/gatsby-ample-debuggers$1`,
-    "^gatsby-ample-seo(.*)$": `<rootDir>/plugins/gatsby-ample-seo$1`
+    "\\@plugins\\/(.*)$": `<rootDir>/plugins/$1`,
+    "\\@root\\/(.*)$": `<rootDir>/$1`,
+    "\\@src\\/(.*)$": `<rootDir>/src/$1`
   },
   testPathIgnorePatterns: [
     `node_modules`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,13 @@ module.exports = {
   },
   moduleNameMapper: {
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
-    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`
+    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,
+    "\\~components\\/(.*)$": `<rootDir>/src/components/$1`,
+    "\\~layout(.*)$": `<rootDir>/src/layout$1`,
+    "\\~root\\/(.*)$": `<rootDir>/$1`,
+    "\\~templates\\/(.*)$": `<rootDir>/src/templates/$1`,
+    "^gatsby-ample-debuggers(.*)$": `<rootDir>/plugins/gatsby-ample-debuggers$1`,
+    "^gatsby-ample-seo(.*)$": `<rootDir>/plugins/gatsby-ample-seo$1`
   },
   testPathIgnorePatterns: [
     `node_modules`,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~components/*": ["./src/components/*"],
+      "~layout/*": ["./src/layout/*"],
+      "~root/*": ["./*"],
+      "~templates/*": ["./src/templates/*"],
+      "gatsby-ample-debuggers/*": ["./plugins/gatsby-ample-debuggers/*"],
+      "gatsby-ample-seo/*": ["./plugins/gatsby-ample-seo/*"]
+    }
+  },
+  "exclude": ["node_modules", "public"]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,12 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "~components/*": ["./src/components/*"],
-      "~layout/*": ["./src/layout/*"],
-      "~root/*": ["./*"],
-      "~templates/*": ["./src/templates/*"],
-      "gatsby-ample-debuggers/*": ["./plugins/gatsby-ample-debuggers/*"],
-      "gatsby-ample-seo/*": ["./plugins/gatsby-ample-seo/*"]
+      "@plugins/*": ["./plugins/*"],
+      "@root/*": ["./*"],
+      "@src/*": ["./src/*"]
     }
   },
   "exclude": ["node_modules", "public"]

--- a/playground.config.js
+++ b/playground.config.js
@@ -1,11 +1,11 @@
-import * as Button from "~components/button"
-// import * as Dropdown from "~components/dropdown"
-import * as Form from "~components/form"
-import * as Image from "~components/image"
-import * as Link from "~components/link"
-import * as SVG from "~components/svg"
+import * as Button from "@src/components/button"
+// import * as Dropdown from "@src/components/dropdown"
+import * as Form from "@src/components/form"
+import * as Image from "@src/components/image"
+import * as Link from "@src/components/link"
+import * as SVG from "@src/components/svg"
 
-import * as Page from "~templates/page"
+import * as Page from "@src/templates/page"
 
 export default {
   title: "Ample Playground",

--- a/playground.config.js
+++ b/playground.config.js
@@ -1,11 +1,11 @@
-import * as Button from "components/button"
-// import * as Dropdown from "components/dropdown"
-import * as Form from "components/form"
-import * as Image from "components/image"
-import * as Link from "components/link"
-import * as SVG from "components/svg"
+import * as Button from "~components/button"
+// import * as Dropdown from "~components/dropdown"
+import * as Form from "~components/form"
+import * as Image from "~components/image"
+import * as Link from "~components/link"
+import * as SVG from "~components/svg"
 
-import * as Page from "templates/page"
+import * as Page from "~templates/page"
 
 export default {
   title: "Ample Playground",

--- a/plugins/gatsby-ample-generator/lib/templates/template/adapter.js
+++ b/plugins/gatsby-ample-generator/lib/templates/template/adapter.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 
 import { normalizeSEO } from "../../helpers"
 
-import SEO from "~components/seo"
+import SEO from "@src/components/seo"
 
 import Template from "./template"
 

--- a/plugins/gatsby-ample-generator/lib/templates/template/adapter.js
+++ b/plugins/gatsby-ample-generator/lib/templates/template/adapter.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 
 import { normalizeSEO } from "../../helpers"
 
-import SEO from "../../components/seo"
+import SEO from "~components/seo"
 
 import Template from "./template"
 

--- a/plugins/gatsby-ample-generator/lib/templates/template/template.js
+++ b/plugins/gatsby-ample-generator/lib/templates/template/template.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import Layout from "~layout"
+import Layout from "@src/layout"
 
 import styles from "./styles.module.scss"
 

--- a/plugins/gatsby-ample-generator/lib/templates/template/template.js
+++ b/plugins/gatsby-ample-generator/lib/templates/template/template.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import Layout from "../../layout"
+import Layout from "~layout"
 
 import styles from "./styles.module.scss"
 

--- a/plugins/gatsby-ample-playground/README.md
+++ b/plugins/gatsby-ample-playground/README.md
@@ -25,10 +25,10 @@ The playground configuration file lives at the root of the project at `playgroun
 A single default export is all that is expected from this file. Here is an example, with the keys explained below:
 
 ```js
-import * as Button from "~components/button"
-import * as Card from "~components/card"
+import * as Button from "@src/components/button"
+import * as Card from "@src/components/card"
 
-import * as Page from "~templates/page"
+import * as Page from "@src/templates/page"
 
 export default {
   title: "Ample Playground",

--- a/plugins/gatsby-ample-playground/README.md
+++ b/plugins/gatsby-ample-playground/README.md
@@ -25,10 +25,10 @@ The playground configuration file lives at the root of the project at `playgroun
 A single default export is all that is expected from this file. Here is an example, with the keys explained below:
 
 ```js
-import * as Button from "components/button"
-import * as Card from "components/card"
+import * as Button from "~components/button"
+import * as Card from "~components/card"
 
-import * as Page from "templates/page"
+import * as Page from "~templates/page"
 
 export default {
   title: "Ample Playground",

--- a/plugins/gatsby-ample-playground/src/templates/components/index.js
+++ b/plugins/gatsby-ample-playground/src/templates/components/index.js
@@ -4,7 +4,7 @@ import lodash from "lodash"
 
 import Variations from "../../components/variations"
 
-import config from "~root/playground.config"
+import config from "@root/playground.config"
 
 import styles from "./styles.module.scss"
 

--- a/plugins/gatsby-ample-playground/src/templates/components/index.js
+++ b/plugins/gatsby-ample-playground/src/templates/components/index.js
@@ -4,7 +4,7 @@ import lodash from "lodash"
 
 import Variations from "../../components/variations"
 
-import config from "root/playground.config"
+import config from "~root/playground.config"
 
 import styles from "./styles.module.scss"
 

--- a/plugins/gatsby-ample-playground/src/templates/templates/index.js
+++ b/plugins/gatsby-ample-playground/src/templates/templates/index.js
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import { Helmet } from "react-helmet"
 import lodash from "lodash"
 
-import config from "root/playground.config"
+import config from "~root/playground.config"
 
 const TemplatesPlayground = () => {
   if (Object.entries(config.templates || {}).length === 0) return "Could not find templates"

--- a/plugins/gatsby-ample-playground/src/templates/templates/index.js
+++ b/plugins/gatsby-ample-playground/src/templates/templates/index.js
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import { Helmet } from "react-helmet"
 import lodash from "lodash"
 
-import config from "~root/playground.config"
+import config from "@root/playground.config"
 
 const TemplatesPlayground = () => {
   if (Object.entries(config.templates || {}).length === 0) return "Could not find templates"

--- a/src/components/button/__snapshots__/test.spec.js.snap
+++ b/src/components/button/__snapshots__/test.spec.js.snap
@@ -3,7 +3,8 @@
 exports[`Button renders correctly 1`] = `
 <a
   className="button"
-  rel="noopener"
-  target="_blank"
-/>
+  href="/"
+>
+  Hello World
+</a>
 `;

--- a/src/components/button/fixtures.js
+++ b/src/components/button/fixtures.js
@@ -4,5 +4,9 @@ export default {
   default: {
     children: faker.lorem.words(2),
     to: faker.internet.url()
+  },
+  fixed: {
+    children: "Hello World",
+    to: "/"
   }
 }

--- a/src/components/button/test.spec.js
+++ b/src/components/button/test.spec.js
@@ -1,11 +1,11 @@
 import React from "react"
 import renderer from "react-test-renderer"
 
-import Button from "./"
+import { component as Button, fixtures } from "."
 
 describe("Button", () => {
   it("renders correctly", () => {
-    const tree = renderer.create(<Button label="Hello World" url="/" />).toJSON()
+    const tree = renderer.create(<Button {...fixtures.fixed} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -2,9 +2,9 @@ import React from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
 
-import Link from "~components/link"
-import Button from "~components/button"
-import Image from "~components/image"
+import Link from "@src/components/link"
+import Button from "@src/components/button"
+import Image from "@src/components/image"
 
 import styles from "./styles.module.scss"
 

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -2,9 +2,9 @@ import React from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
 
-import Link from "../link"
-import Button from "../button"
-import Image from "../image"
+import Link from "~components/link"
+import Button from "~components/button"
+import Image from "~components/image"
 
 import styles from "./styles.module.scss"
 

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -17,7 +17,7 @@ const Card = ({ body, button, image, theme, url }) => {
     <div className={classes}>
       {image && <Image src={image} />}
       {body && <div dangerouslySetInnerHTML={{ __html: body }} />}
-      {button && <Button label={button.label} url={button.url} />}
+      {button && <Button to={button.url}>{button.label}</Button>}
     </div>
   )
 

--- a/src/components/svg/test.spec.js
+++ b/src/components/svg/test.spec.js
@@ -3,8 +3,11 @@ import renderer from "react-test-renderer"
 
 import SVG from "."
 
+import MediaQueryDebugger from "gatsby-ample-seo/src/components/seo"
+
 describe("SVG", () => {
   it("renders correctly", () => {
+    MediaQueryDebugger
     const tree = renderer.create(<SVG name="bars" />).toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/src/components/svg/test.spec.js
+++ b/src/components/svg/test.spec.js
@@ -3,7 +3,7 @@ import renderer from "react-test-renderer"
 
 import SVG from "."
 
-import MediaQueryDebugger from "gatsby-ample-seo/src/components/seo"
+import MediaQueryDebugger from "@plugins/gatsby-ample-seo/src/components/seo"
 
 describe("SVG", () => {
   it("renders correctly", () => {

--- a/src/layout/footer/fixtures.js
+++ b/src/layout/footer/fixtures.js
@@ -1,10 +1,32 @@
-export const footer_test_data = {
-  policy_links: [
-    { url: "#", label: "Privacy Policy" },
-    { url: "#", label: "Terms of Service" }
-  ],
-  social_links: [
-    { url: "#", icon: "twitter" },
-    { url: "#", icon: "facebook" }
-  ]
+export default {
+  default: {
+    menus: [
+      {
+        label: "Quisque",
+        links: [
+          { url: "#", label: "Vestibulum vitae" },
+          { url: "#", label: "Pellentesque tempor venenatis" },
+          { url: "#", label: "Fusce molestie" },
+          { url: "#", label: "Etiam in lacinia dolor" }
+        ]
+      },
+      {
+        label: "Vestibulum",
+        links: [
+          { url: "#", label: "Fusce molestie" },
+          { url: "#", label: "Pellentesque venenatis" },
+          { url: "#", label: "Vestibulum vitae" },
+          { url: "#", label: "lacinia dolor" }
+        ]
+      }
+    ],
+    policy_links: [
+      { url: "#", label: "Privacy Policy" },
+      { url: "#", label: "Terms of Service" }
+    ],
+    social_links: [
+      { url: "#", icon: "twitter" },
+      { url: "#", icon: "facebook" }
+    ]
+  }
 }

--- a/src/layout/footer/link-list/__snapshots__/test.spec.js.snap
+++ b/src/layout/footer/link-list/__snapshots__/test.spec.js.snap
@@ -3,5 +3,42 @@
 exports[`LinkList renders link list correctly 1`] = `
 <ul
   className="link_list"
-/>
+>
+  <li>
+    <a
+      href="#"
+      rel="noopener"
+      target="_blank"
+    >
+      Vestibulum vitae
+    </a>
+  </li>
+  <li>
+    <a
+      href="#"
+      rel="noopener"
+      target="_blank"
+    >
+      Pellentesque tempor venenatis
+    </a>
+  </li>
+  <li>
+    <a
+      href="#"
+      rel="noopener"
+      target="_blank"
+    >
+      Fusce molestie
+    </a>
+  </li>
+  <li>
+    <a
+      href="#"
+      rel="noopener"
+      target="_blank"
+    >
+      Etiam in lacinia dolor
+    </a>
+  </li>
+</ul>
 `;

--- a/src/layout/footer/link-list/component.js
+++ b/src/layout/footer/link-list/component.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import Link from "../../../components/link"
+import Link from "~components/link"
 
 import styles from "./styles.module.scss"
 

--- a/src/layout/footer/link-list/component.js
+++ b/src/layout/footer/link-list/component.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import Link from "~components/link"
+import Link from "@src/components/link"
 
 import styles from "./styles.module.scss"
 

--- a/src/layout/footer/link-list/fixtures.js
+++ b/src/layout/footer/link-list/fixtures.js
@@ -1,22 +1,11 @@
 export default {
-  menus: [
-    {
-      label: "Quisque",
-      links: [
-        { url: "#", label: "Vestibulum vitae" },
-        { url: "#", label: "Pellentesque tempor venenatis" },
-        { url: "#", label: "Fusce molestie" },
-        { url: "#", label: "Etiam in lacinia dolor" }
-      ]
-    },
-    {
-      label: "Vestibulum",
-      links: [
-        { url: "#", label: "Fusce molestie" },
-        { url: "#", label: "Pellentesque venenatis" },
-        { url: "#", label: "Vestibulum vitae" },
-        { url: "#", label: "lacinia dolor" }
-      ]
-    }
-  ]
+  default: {
+    label: "Quisque",
+    links: [
+      { url: "#", label: "Vestibulum vitae" },
+      { url: "#", label: "Pellentesque tempor venenatis" },
+      { url: "#", label: "Fusce molestie" },
+      { url: "#", label: "Etiam in lacinia dolor" }
+    ]
+  }
 }

--- a/src/layout/footer/link-list/test.spec.js
+++ b/src/layout/footer/link-list/test.spec.js
@@ -7,7 +7,7 @@ import fixtures from "./fixtures"
 
 describe("LinkList", () => {
   it("renders link list correctly", () => {
-    const tree = renderer.create(<LinkList menus={fixtures.vertical} />).toJSON()
+    const tree = renderer.create(<LinkList {...fixtures.default} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/src/layout/footer/social-nav/component.js
+++ b/src/layout/footer/social-nav/component.js
@@ -1,0 +1,33 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import Link from "~components/link"
+import SVG from "~components/svg"
+
+import styles from "./styles.module.scss"
+
+const SocialNav = ({ links }) => (
+  <nav className={styles.social_nav}>
+    {links.map((link, index) => (
+      <Link to={link.url} key={index}>
+        <SVG name={link.icon} />
+      </Link>
+    ))}
+  </nav>
+)
+
+SocialNav.propTypes = {
+  /**
+   * An array of social links.
+   */
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      icon: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired
+    })
+  ).isRequired
+}
+
+SocialNav.defaultProps = {}
+
+export default SocialNav

--- a/src/layout/footer/social-nav/component.js
+++ b/src/layout/footer/social-nav/component.js
@@ -1,8 +1,8 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import Link from "~components/link"
-import SVG from "~components/svg"
+import Link from "@src/components/link"
+import SVG from "@src/components/svg"
 
 import styles from "./styles.module.scss"
 

--- a/src/layout/footer/social-nav/fixtures.js
+++ b/src/layout/footer/social-nav/fixtures.js
@@ -1,0 +1,8 @@
+export default {
+  default: {
+    links: [
+      { url: "#", icon: "twitter" },
+      { url: "#", icon: "facebook" }
+    ]
+  }
+}

--- a/src/layout/footer/social-nav/index.js
+++ b/src/layout/footer/social-nav/index.js
@@ -1,33 +1,6 @@
-import React from "react"
-import PropTypes from "prop-types"
+import component from "./component"
+import fixtures from "./fixtures"
 
-import Link from "~components/link"
-import SVG from "~components/svg"
+export default component
 
-import styles from "./styles.module.scss"
-
-const SocialNav = ({ links }) => (
-  <nav className={styles.social_nav}>
-    {links.map((link, index) => (
-      <Link to={link.url} key={index}>
-        <SVG name={link.icon} />
-      </Link>
-    ))}
-  </nav>
-)
-
-SocialNav.propTypes = {
-  /**
-   * An array of social links.
-   */
-  links: PropTypes.arrayOf(
-    PropTypes.shape({
-      icon: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired
-    })
-  ).isRequired
-}
-
-SocialNav.defaultProps = {}
-
-export default SocialNav
+export { component, fixtures }

--- a/src/layout/footer/social-nav/index.js
+++ b/src/layout/footer/social-nav/index.js
@@ -1,8 +1,8 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import Link from "../../../components/link"
-import SVG from "../../../components/svg"
+import Link from "~components/link"
+import SVG from "~components/svg"
 
 import styles from "./styles.module.scss"
 

--- a/src/layout/footer/social-nav/test.spec.js
+++ b/src/layout/footer/social-nav/test.spec.js
@@ -1,12 +1,11 @@
 import React from "react"
 import renderer from "react-test-renderer"
 
-import SocialNav from "."
-import { footer_test_data } from "./../fixtures"
+import { component as SocialNav, fixtures } from "."
 
 describe("SocialNav", () => {
   it("renders correctly", () => {
-    const tree = renderer.create(<SocialNav links={footer_test_data.social_links} />).toJSON()
+    const tree = renderer.create(<SocialNav {...fixtures.default} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/src/layout/footer/test.spec.js
+++ b/src/layout/footer/test.spec.js
@@ -3,20 +3,12 @@ import renderer from "react-test-renderer"
 
 import Footer from "./"
 
-import menu_fixtures from "./link-list/fixtures"
-import { footer_test_data } from "./fixtures"
+import fixtures from "./fixtures"
 
 describe("Footer", () => {
   it("renders correctly", () => {
     const tree = renderer
-      .create(
-        <Footer
-          copyright="2020, All Rights Reserved"
-          menus={menu_fixtures.menus}
-          policy_links={footer_test_data.policy_links}
-          social_links={footer_test_data.social_links}
-        />
-      )
+      .create(<Footer copyright="2020, All Rights Reserved" {...fixtures.default} />)
       .toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/src/layout/header/index.js
+++ b/src/layout/header/index.js
@@ -2,8 +2,8 @@ import React, { useState } from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
 
-import Link from "./../../components/link"
-import SVG from "../../components/svg"
+import Link from "~components/link"
+import SVG from "~components/svg"
 
 import Navigation from "./navigation"
 

--- a/src/layout/header/index.js
+++ b/src/layout/header/index.js
@@ -2,8 +2,8 @@ import React, { useState } from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
 
-import Link from "~components/link"
-import SVG from "~components/svg"
+import Link from "@src/components/link"
+import SVG from "@src/components/svg"
 
 import Navigation from "./navigation"
 

--- a/src/layout/header/navigation/component.js
+++ b/src/layout/header/navigation/component.js
@@ -2,9 +2,9 @@ import React from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
 
-import Button from "~components/button"
+import Button from "@src/components/button"
 import { Dropdown, DropdownMenu, DropdownTrigger } from "./dropdown"
-import Link from "~components/link"
+import Link from "@src/components/link"
 
 import styles from "./styles.module.scss"
 

--- a/src/layout/header/navigation/component.js
+++ b/src/layout/header/navigation/component.js
@@ -2,9 +2,9 @@ import React from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
 
-import Button from "../../../components/button"
+import Button from "~components/button"
 import { Dropdown, DropdownMenu, DropdownTrigger } from "./dropdown"
-import Link from "../../../components/link"
+import Link from "~components/link"
 
 import styles from "./styles.module.scss"
 

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -5,8 +5,7 @@ import Footer from "./footer"
 import Header from "./header"
 import { DebugMediaQueries } from "gatsby-ample-debuggers"
 
-import footer_menu_fixtures from "./footer/link-list/fixtures"
-import { footer_test_data } from "./footer/fixtures"
+import footer_test_data from "./footer/fixtures"
 import header_fixture from "./header/navigation/fixtures"
 
 import Card from "~components/card"
@@ -54,12 +53,7 @@ const Layout = ({ children }) => (
       />
     </Grid>
 
-    <Footer
-      copyright="2020, All Rights Reserved"
-      menus={footer_menu_fixtures.menus}
-      policy_links={footer_test_data.policy_links}
-      social_links={footer_test_data.social_links}
-    />
+    <Footer copyright="2020, All Rights Reserved" {...footer_test_data.default} />
 
     <DebugMediaQueries isShowing={process.env.GATSBY_DEBUG_MEDIA_QUERIES} />
   </>

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -3,14 +3,14 @@ import PropTypes from "prop-types"
 
 import Footer from "./footer"
 import Header from "./header"
-import { DebugMediaQueries } from "../../plugins/gatsby-ample-debuggers"
+import { DebugMediaQueries } from "gatsby-ample-debuggers"
 
 import footer_menu_fixtures from "./footer/link-list/fixtures"
 import { footer_test_data } from "./footer/fixtures"
 import header_fixture from "./header/navigation/fixtures"
 
-import Card from "./../components/card"
-import Grid from "./../components/grid"
+import Card from "~components/card"
+import Grid from "~components/grid"
 
 const Layout = ({ children }) => (
   <>

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -3,13 +3,13 @@ import PropTypes from "prop-types"
 
 import Footer from "./footer"
 import Header from "./header"
-import { DebugMediaQueries } from "gatsby-ample-debuggers"
+import { DebugMediaQueries } from "@plugins/gatsby-ample-debuggers"
 
 import footer_test_data from "./footer/fixtures"
 import header_fixture from "./header/navigation/fixtures"
 
-import Card from "~components/card"
-import Grid from "~components/grid"
+import Card from "@src/components/card"
+import Grid from "@src/components/grid"
 
 const Layout = ({ children }) => (
   <>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-import Layout from "~layout"
+import Layout from "@src/layout"
 
 const NotFoundPage = () => (
   <Layout>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-import Layout from "../layout"
+import Layout from "~layout"
 
 const NotFoundPage = () => (
   <Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,7 @@ import React from "react"
 import { graphql } from "gatsby"
 import PropTypes from "prop-types"
 
-import Page from "../templates/page/adapter"
+import Page from "~templates/page/adapter"
 
 const HomePageAdapter = ({ data, location }) => <Page data={data} location={location} />
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,7 @@ import React from "react"
 import { graphql } from "gatsby"
 import PropTypes from "prop-types"
 
-import Page from "~templates/page/adapter"
+import Page from "@src/templates/page/adapter"
 
 const HomePageAdapter = ({ data, location }) => <Page data={data} location={location} />
 

--- a/src/sections/container/index.js
+++ b/src/sections/container/index.js
@@ -4,10 +4,10 @@ import classNames from "classnames/bind"
 
 import styles from "./styles.module.scss"
 
-import Button from "~components/button"
-import Content from "~components/content"
-import Form from "~components/form"
-import Image from "~components/image"
+import Button from "@src/components/button"
+import Content from "@src/components/content"
+import Form from "@src/components/form"
+import Image from "@src/components/image"
 
 const componentMap = {
   "component-button": Button,

--- a/src/sections/container/index.js
+++ b/src/sections/container/index.js
@@ -4,10 +4,10 @@ import classNames from "classnames/bind"
 
 import styles from "./styles.module.scss"
 
-import Button from "../../components/button"
-import Content from "../../components/content"
-import Form from "../../components/form"
-import Image from "../../components/image"
+import Button from "~components/button"
+import Content from "~components/content"
+import Form from "~components/form"
+import Image from "~components/image"
 
 const componentMap = {
   "component-button": Button,

--- a/src/templates/page/__snapshots__/test.spec.js.snap
+++ b/src/templates/page/__snapshots__/test.spec.js.snap
@@ -233,7 +233,9 @@ Array [
     <div
       className="page"
     >
-      <h1 />
+      <h1>
+        Default Page
+      </h1>
     </div>
   </main>,
   <div
@@ -256,9 +258,12 @@ Array [
       />
       <a
         className="button"
+        href="#"
         rel="noopener"
         target="_blank"
-      />
+      >
+        Learn more
+      </a>
     </div>
     <div
       className="card theme_2"
@@ -277,9 +282,12 @@ Array [
       />
       <a
         className="button"
+        href="#"
         rel="noopener"
         target="_blank"
-      />
+      >
+        Learn more
+      </a>
     </div>
     <div
       className="card theme_1"
@@ -298,9 +306,12 @@ Array [
       />
       <a
         className="button"
+        href="#"
         rel="noopener"
         target="_blank"
-      />
+      >
+        Learn more
+      </a>
     </div>
   </div>,
   <footer

--- a/src/templates/page/adapter.js
+++ b/src/templates/page/adapter.js
@@ -2,9 +2,7 @@ import React from "react"
 import { graphql } from "gatsby"
 import PropTypes from "prop-types"
 
-import { normalizeSEO } from "../../../plugins/gatsby-ample-seo"
-
-import { SEO } from "../../../plugins/gatsby-ample-seo"
+import { normalizeSEO, SEO } from "gatsby-ample-seo"
 
 import Page from "./"
 

--- a/src/templates/page/adapter.js
+++ b/src/templates/page/adapter.js
@@ -2,7 +2,7 @@ import React from "react"
 import { graphql } from "gatsby"
 import PropTypes from "prop-types"
 
-import { normalizeSEO, SEO } from "gatsby-ample-seo"
+import { normalizeSEO, SEO } from "@plugins/gatsby-ample-seo"
 
 import Page from "./"
 

--- a/src/templates/page/template.js
+++ b/src/templates/page/template.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import styles from "./styles.module.scss"
 
-import Layout from "../../layout"
+import Layout from "~layout"
 
 import Container from "../../sections/container"
 

--- a/src/templates/page/template.js
+++ b/src/templates/page/template.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import styles from "./styles.module.scss"
 
-import Layout from "~layout"
+import Layout from "@src/layout"
 
 import Container from "../../sections/container"
 

--- a/src/templates/page/test.spec.js
+++ b/src/templates/page/test.spec.js
@@ -1,11 +1,11 @@
 import React from "react"
 import renderer from "react-test-renderer"
 
-import PageTemplate from "./"
+import { template as PageTemplate, fixtures } from "."
 
 describe("PageTemplate", () => {
   it("renders correctly", () => {
-    const tree = renderer.create(<PageTemplate sections={[]} />).toJSON()
+    const tree = renderer.create(<PageTemplate {...fixtures.default} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
This _mostly_ adds support for alias imports. See new section on the README for more info.

I also combed through the console warnings that were emitted from jest specs and fixed those. That was a good exercise as it enabled me to touch a few fixtures files to make them more consistent with our (new) convention.