### PR TITLE
Add option to disable redirects plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,9 +32,19 @@ module.exports = {
     // Creates meta tags for every page
     // src/templates/page/adapter.js. (See plugins/gatsby-ample-seo.)
     `gatsby-ample-seo`,
-    // Creates Gatsby and Netlify redirects for records in
-    // src/content/redirects. (See plugins/gatsby-ample-redirects.)
-    `gatsby-ample-redirects`,
+    /**
+     * Creates Gatsby and Netlify redirects for records in
+     * src/content/redirects. (See plugins/gatsby-ample-redirects.)
+     */
+    {
+      resolve: `gatsby-ample-redirects`,
+      options: {
+        // Setting GATSBY_REDIRECTS_DISABLED="true" disables redirects. This
+        // applies to both in-app redirects and those written to _redirects for
+        // use by Netlify.
+        disable: process.env.GATSBY_REDIRECTS_DISABLED === "true"
+      }
+    },
     /**
      * Creates playgrounds from .mdx files in src/templates and src/components.
      */

--- a/plugins/gatsby-ample-redirects/README.md
+++ b/plugins/gatsby-ample-redirects/README.md
@@ -1,0 +1,23 @@
+# gatsby-ample-redirects
+
+Adds redirects from data within local markdown files.
+
+This plugin relies on the following:
+
+- Local markdown data files in `src/content/redirects`. (See below for structure.)
+- `gatsby-remark-ample` for generating the query that returns only the redirect objects.
+
+It uses the [`createRedirect`](https://www.gatsbyjs.org/docs/actions/#createRedirect) Gatsby action to build redirects within the React application. In addition, if you have [`gatsby-plugin-netlify`](https://www.gatsbyjs.org/packages/gatsby-plugin-netlify/) installed, it will write the redirects to a `_redirects` file in `public` upon building the project.
+
+## File Structure
+
+The files in `src/content/redirects` may have the following keys:
+
+- `title` (required): The source path or URL.
+- `destination` (required): The destination path or URL.
+- `force`: If set to `true` will force the redirect even if the page exists.
+- `permanent`: Treats the redirect as `301` if set to true. Otherwise, it will be a `302` redirect.
+
+## Usage & Disabling
+
+It is installed by default in `gatsby-config.js`. To disable, you can remove the configuration, or pass the `disable` option. You can disable without touching the code by setting an environment of `GATSBY_REDIRECTS_DISABLED` to `true`.

--- a/plugins/gatsby-ample-redirects/gatsby-node.js
+++ b/plugins/gatsby-ample-redirects/gatsby-node.js
@@ -1,4 +1,6 @@
-exports.createPages = ({ graphql, actions }) => {
+exports.createPages = ({ graphql, actions }, pluginOptions = {}) => {
+  if (pluginOptions.disable) return
+
   return graphql(`
     {
       redirects: allRedirect {


### PR DESCRIPTION
This is useful mostly when developing locally and wanting to work with a file that you've redirected on the production build.

Eventually we'll come up with a better workflow for publishing pages, but this serves as an interim step.

I've also added documentation for the redirects plugin.