### PR TITLE
[Fixes #91] Add support for global state management

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,10 @@
+import { Provider } from "./src/services/provider"
+
 import "./src/styles/libs/sanitize.scss"
 import "./src/styles/global-styles.scss"
 import "./src/styles/global-utilities.scss"
+
+// ---------------------------------------- | Image Polyfill (IntersectionObserver)
 
 export const onClientEntry = () => {
   // IntersectionObserver polyfill for gatsby-background-image (Safari, IE)
@@ -9,6 +13,8 @@ export const onClientEntry = () => {
     console.log(`# IntersectionObserver is polyfilled!`)
   }
 }
+
+// ---------------------------------------- | Scroll To Anchor
 
 export const onRouteUpdate = ({ location }) => scrollToAnchor(location)
 
@@ -30,3 +36,7 @@ function scrollToAnchor(location, mainNavHeight = 0) {
 
   return true
 }
+
+// ---------------------------------------- | Global State Management
+
+export const wrapRootElement = Provider

--- a/src/services/provider/README.md
+++ b/src/services/provider/README.md
@@ -1,0 +1,44 @@
+# Global State Management
+
+The provider service establishes a means for working with global state. The `<Provider />` component in this directory (in `component.js`) holds the global state. This component wraps the root level component, which is configured in `gatsby-browser.js`.
+
+The example used by default shows how you may use a global `theme` value. The provider service exposes the getter `theme` value, as well as the setter `setTheme` function. This is achieved via the `useState` hook. You're welcome to remove the `theme` state and add others as needed. By default, this component is not in use throughout the application.
+
+You can use the global state in a component or template like so:
+
+```js
+import React from "react"
+import ProviderContext from "@src/services/provider"
+
+const MyComponent = () => {
+  return (
+    <ProviderContext.Consumer>
+      {context => {
+        return <p>The theme is: {context.theme}</p>
+      }}
+    </ProviderContext.Consumer>
+  )
+}
+
+export default MyComponent
+```
+
+If you would like to call a setter method while in the rendering cycle of a component, the easiest way to do so and avoid a React error is to shove it in a brief `setTimeout` function:
+
+```js
+import React from "react"
+import ProviderContext from "@src/services/provider"
+
+const MyComponent = () => {
+  return (
+    <ProviderContext.Consumer>
+      {context => {
+        setTimeout(() => context.setTheme("dark"), 1)
+        return <p>The theme should now have changed to "dark."</p>
+      }}
+    </ProviderContext.Consumer>
+  )
+}
+
+export default MyComponent
+```

--- a/src/services/provider/component.js
+++ b/src/services/provider/component.js
@@ -1,0 +1,19 @@
+import React, { createContext, useState } from "react"
+import PropTypes from "prop-types"
+
+const ProviderContext = createContext()
+
+const Provider = ({ children }) => {
+  const [theme, setTheme] = useState(null)
+
+  return <ProviderContext.Provider value={{ theme, setTheme }}>{children}</ProviderContext.Provider>
+}
+
+Provider.propTypes = {
+  children: PropTypes.node.isRequired
+}
+
+/* eslint-disable-next-line react/display-name, react/prop-types */
+export default ({ element }) => <Provider>{element}</Provider>
+
+export { ProviderContext }

--- a/src/services/provider/index.js
+++ b/src/services/provider/index.js
@@ -1,0 +1,5 @@
+import Provider, { ProviderContext } from "./component"
+
+export default ProviderContext
+
+export { Provider, ProviderContext }


### PR DESCRIPTION
## Task

#91 

## Solution

Followed the example from #91 and provided a means to work with global state without actually implementing it anywhere. (We don't typically use it by default, but it could come in handy, and it's a nice pattern to have on hand.)
