### PR TITLE
Introduce programmatic page paths for Page objects

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,50 +19,23 @@ module.exports = {
         }
       }
     },
-    /**
-     * Uses schema.yml at the root of the project to explicitly declare GraphQL
-     * schema. (See plugins/gatsby-ample-schema.)
-     */
     `gatsby-ample-schema`,
-    /**
-     * Looks in src/content and passes every page (except index.md) to
-     * src/templates/page/adapter.js. (See plugins/gatsby-ample-pages.)
-     */
     `gatsby-ample-pages`,
-    // Creates meta tags for every page
-    // src/templates/page/adapter.js. (See plugins/gatsby-ample-seo.)
     `gatsby-ample-seo`,
-    /**
-     * Creates Gatsby and Netlify redirects for records in
-     * src/content/redirects. (See plugins/gatsby-ample-redirects.)
-     */
+    `gatsby-ample-debuggers`,
+    `gatsby-ample-linters`,
     {
       resolve: `gatsby-ample-redirects`,
       options: {
-        // Setting GATSBY_REDIRECTS_DISABLED="true" disables redirects. This
-        // applies to both in-app redirects and those written to _redirects for
-        // use by Netlify.
         disable: process.env.GATSBY_REDIRECTS_DISABLED === "true"
       }
     },
-    /**
-     * Creates playgrounds from components and templates. (See
-     * plugins/gatsby-ample-playground.)
-     */
     {
       resolve: `gatsby-ample-playground`,
       options: {
-        // Setting GATSBY_PLAYGROUND_DISABLED="true" disables the playground
-        // build.
         disable: process.env.GATSBY_PLAYGROUND_DISABLED === "true"
       }
     },
-    // Adds a debugger for media queries
-    // src/layout. (See plugins/gatsby-ample-debuggers.)
-    `gatsby-ample-debuggers`,
-    // Adds linters for local development
-    // (See plugins/gatsby-ample-linters.)
-    `gatsby-ample-linters`,
     `gatsby-plugin-react-helmet`,
     {
       resolve: "gatsby-source-filesystem",
@@ -91,17 +64,12 @@ module.exports = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
-          // gatsby-remark-relative-images must
-          // go before gatsby-remark-images
           {
             resolve: `gatsby-remark-relative-images`
           },
           {
             resolve: `gatsby-remark-images`,
             options: {
-              // It's important to specify the maxWidth (in pixels) of
-              // the content container as this plugin uses this as the
-              // base for generating different widths of each image.
               maxWidth: 1440
             }
           }
@@ -110,19 +78,11 @@ module.exports = {
     },
     {
       resolve: `gatsby-remark-ample`,
-      // Commented lines are the plugin's default options. Read more here:
-      // https://github.com/ample/gatsby-remark-ample
       options: {
-        // contentSrc: "src/content/",
-        // imageExtensions: [".jpg", ".jpeg", ".png"],
         imageSrc: path.join(__dirname, "static"),
-        // imageSuffix: "_src",
-        // markdownSuffix: "_md",
-        // modelField: "model",
         models: ["AdminReferences", "AdminSeo", "Form", "Page", "Redirect"],
         plugins: ["gatsby-ample-pages"],
         projectRoot: path.join(__dirname)
-        // seoField: "seo",
       }
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -120,8 +120,9 @@ module.exports = {
         // markdownSuffix: "_md",
         // modelField: "model",
         models: ["AdminReferences", "AdminSeo", "Form", "Page", "Redirect"],
+        plugins: ["gatsby-ample-pages"],
         projectRoot: path.join(__dirname)
-        // seoField: "seo"
+        // seoField: "seo",
       }
     },
     {

--- a/plugins/gatsby-ample-pages/remark-plugin.js
+++ b/plugins/gatsby-ample-pages/remark-plugin.js
@@ -1,10 +1,18 @@
 const get = require("lodash/get")
+const getPagePath = require("./lib/get-page-path")
 
+/**
+ * Adds a pagePath property to every Page object.
+ *
+ * @param {object} node Node object coming from gatsby-remark-ample/gatsby-node.js
+ */
 exports.initNode = node => {
+  // We're only processing pages.
   if (get(node, "internal.type") !== "Page") {
     return node
   }
-
-  // node.url = "/hello-world"
+  // Add the pagePath property.
+  node.pagePath = getPagePath(node)
+  // Return the transformed node, which is expected by gatsby-remark-ample.
   return node
 }

--- a/plugins/gatsby-ample-pages/remark-plugin.js
+++ b/plugins/gatsby-ample-pages/remark-plugin.js
@@ -1,0 +1,10 @@
+const get = require("lodash/get")
+
+exports.initNode = node => {
+  if (get(node, "internal.type") !== "Page") {
+    return node
+  }
+
+  // node.url = "/hello-world"
+  return node
+}

--- a/plugins/gatsby-remark-ample/gatsby-node.js
+++ b/plugins/gatsby-remark-ample/gatsby-node.js
@@ -146,8 +146,6 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
   // Run the initNode API.
   pluginAPIs.initNode.map(func => (newNode = func(newNode)))
 
-  console.log("NEW NODE", newNode)
-
   // Create the new node and build a relationship to the parent, so we can use
   // childMarkdownRemark to get to html and other useful attributes.
   actions.createNode(newNode)

--- a/plugins/gatsby-remark-ample/gatsby-node.js
+++ b/plugins/gatsby-remark-ample/gatsby-node.js
@@ -70,8 +70,6 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
     process.exit(1)
   }
 
-  // console.log(pluginAPIs)
-
   // Set the initial state of the frontmatter to be processed as the slug,
   // slugPath, and filePath, along with the frontmatter from the MarkdownRemark
   // node.

--- a/plugins/gatsby-remark-ample/gatsby-node.js
+++ b/plugins/gatsby-remark-ample/gatsby-node.js
@@ -5,6 +5,7 @@ const path = require("path")
 const getOptions = require("./utils/get-options")
 const getPermalink = require("./utils/get-permalink")
 const getFilePath = require("./utils/get-file-path")
+const loadPlugins = require("./utils/load-plugins")
 const processFrontmatter = require("./utils/process-frontmatter")
 
 exports.createSchemaCustomization = ({ actions }, options) => {
@@ -60,6 +61,16 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
   // If the model was not specified, then don't try to create the node because
   // the type is unknown.
   if (!model) return
+
+  // Load plugin APIs.
+  let pluginAPIs
+  try {
+    pluginAPIs = loadPlugins(options.plugins || [])
+  } catch {
+    process.exit(1)
+  }
+
+  // console.log(pluginAPIs)
 
   // Set the initial state of the frontmatter to be processed as the slug,
   // slugPath, and filePath, along with the frontmatter from the MarkdownRemark
@@ -131,6 +142,11 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
     actions.createNode(seoNode)
     set(newNode, "seo", seoNode)
   }
+
+  // Run the initNode API.
+  pluginAPIs.initNode.map(func => (newNode = func(newNode)))
+
+  console.log("NEW NODE", newNode)
 
   // Create the new node and build a relationship to the parent, so we can use
   // childMarkdownRemark to get to html and other useful attributes.

--- a/plugins/gatsby-remark-ample/utils/__fixtures__/remark-plugin.js
+++ b/plugins/gatsby-remark-ample/utils/__fixtures__/remark-plugin.js
@@ -1,7 +1,7 @@
 exports.hello = () => {
-  console.log("123")
+  return "Hello World"
 }
 
 exports.initNode = node => {
-  console.log(node)
+  return node
 }

--- a/plugins/gatsby-remark-ample/utils/__fixtures__/remark-plugin.js
+++ b/plugins/gatsby-remark-ample/utils/__fixtures__/remark-plugin.js
@@ -1,0 +1,7 @@
+exports.hello = () => {
+  console.log("123")
+}
+
+exports.initNode = node => {
+  console.log(node)
+}

--- a/plugins/gatsby-remark-ample/utils/load-plugins.js
+++ b/plugins/gatsby-remark-ample/utils/load-plugins.js
@@ -1,0 +1,26 @@
+// TODO: Add tests for this.
+
+module.exports = plugins => {
+  let pluginAPIs = { initNode: [] }
+
+  plugins.map(plugin => {
+    try {
+      const entryFilePath = `${plugin.resolve}/remark-plugin.js`
+      const funcs = require(entryFilePath)
+      Object.entries(funcs).map(([name, func]) => {
+        console.log(name, typeof func)
+        if (!pluginAPIs[name]) return
+        pluginAPIs[name].push(func)
+      })
+    } catch (err) {
+      console.error(
+        "Could not load gatsby-remark-ample plugin: ",
+        plugin.resolve,
+        "\n",
+        "The plugin must contain a valid remark-plugin.js file in its root."
+      )
+    }
+  })
+
+  return pluginAPIs
+}

--- a/plugins/gatsby-remark-ample/utils/load-plugins.js
+++ b/plugins/gatsby-remark-ample/utils/load-plugins.js
@@ -1,5 +1,3 @@
-// TODO: Add tests for this.
-
 module.exports = plugins => {
   let pluginAPIs = { initNode: [] }
 
@@ -8,17 +6,18 @@ module.exports = plugins => {
       const entryFilePath = `${plugin.resolve}/remark-plugin.js`
       const funcs = require(entryFilePath)
       Object.entries(funcs).map(([name, func]) => {
-        console.log(name, typeof func)
         if (!pluginAPIs[name]) return
         pluginAPIs[name].push(func)
       })
     } catch (err) {
-      console.error(
-        "Could not load gatsby-remark-ample plugin: ",
-        plugin.resolve,
-        "\n",
-        "The plugin must contain a valid remark-plugin.js file in its root."
-      )
+      if (process.env.NODE_ENV !== "test") {
+        console.error(
+          "Could not load gatsby-remark-ample plugin: ",
+          plugin.resolve,
+          "\n",
+          "The plugin must contain a valid remark-plugin.js file in its root."
+        )
+      }
     }
   })
 

--- a/plugins/gatsby-remark-ample/utils/load-plugins.spec.js
+++ b/plugins/gatsby-remark-ample/utils/load-plugins.spec.js
@@ -1,0 +1,17 @@
+const path = require("path")
+
+const loadPlugins = require("./load-plugins")
+
+describe("loadPlugins()", () => {
+  it("returns the base object when it can not find the right file", () => {
+    const plugins = [{ resolve: path.join(__dirname) }]
+    const result = loadPlugins(plugins)
+    expect(result).toEqual({ initNode: [] })
+  })
+  it("loads the necessary functions, using a remark-plugin.js file", () => {
+    const plugins = [{ resolve: path.join(__dirname, "__fixtures__") }]
+    const result = loadPlugins(plugins)
+    const func = require("./__fixtures__/remark-plugin")
+    expect(result).toEqual({ initNode: [func.initNode] })
+  })
+})

--- a/src/components/card/__snapshots__/test.spec.js.snap
+++ b/src/components/card/__snapshots__/test.spec.js.snap
@@ -91,8 +91,7 @@ exports[`Card renders correctly 1`] = `
   />
   <a
     className="button"
-    rel="noopener"
-    target="_blank"
+    href="/"
   >
     Enim
   </a>

--- a/src/components/card/fixtures.js
+++ b/src/components/card/fixtures.js
@@ -6,7 +6,7 @@ export default {
       "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
     button: {
       label: "Enim",
-      url: ""
+      url: "/"
     },
     image: imageFixtures.fluid.src
   }


### PR DESCRIPTION
## Task

The initial task was to attach some sort of `url` field to `Page` objects. Ultimately I called it `pagePath` since that felt more semantic.

## Solution

It also felt like the foundation for several other tasks here. Therefore, I implemented what I've been thinking about for awhile — an API for tapping into `gatsby-remark-ample` during the node creation process.

See docs in the adjusted README.

## Tester Notes

There are new tests, but nothing to note on the front-end. 

---

This is a cool thing that I'm excited about. However, it's just brushing the surface of how powerful it can be, so I want to make sure I'm going about this the right way.

For instance, #201 shows us that we're not defining the schema in a way that is too siloed. This provides a means for sharing processes like node creation and schema definition among multiple plugins, which helps provide a more modular architecture, at least in theory.

That said, please poke holes in this so we can move forward with a more solid product.