### PR TITLE
[Fixes #108] Add option to exclude page from sitemap

### DIFF
--- a/.forestry/front_matter/templates/template-page.yml
+++ b/.forestry/front_matter/templates/template-page.yml
@@ -21,6 +21,12 @@ fields:
   description: Published pages are visible in production, while unpublished pages
     are not. All pages are available in preview.
   default: false
+- name: exclude_from_sitemap
+  type: boolean
+  label: Exclude from Sitemap
+  description: All published pages are included in the sitemap by default. Selecting
+    this option removes this page from the sitemap.
+  default: false
 - name: layout
   type: select
   default: basic
@@ -31,9 +37,9 @@ fields:
     - flexible
     source:
       type: simple
-      section: 
-      file: 
-      path: 
+      section:
+      file:
+      path:
   label: Layout
   description: The layout affects how the page appears on the website, along with
     the fields visible here.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -173,6 +173,38 @@ module.exports = {
       resolve: `gatsby-plugin-sitemap`,
       options: {
         output: `/sitemap.xml`
+        //   query: `
+        //   {
+        //     wp {
+        //       generalSettings {
+        //         siteUrl
+        //       }
+        //     }
+
+        // {
+        //   pages: allPage(filter: {exclude_from_sitemap: {ne: true}, published: {eq: true}}) {
+        //     edges {
+        //       node {
+        //         title
+        //         slugPath
+        //       }
+        //     }
+        //   }
+        // }
+
+        // }`,
+        // resolveSiteUrl: ({site, allSitePage}) => {
+        //   //Alternatively, you may also pass in an environment variable (or any location) at the beginning of your `gatsby-config.js`.
+        //   return site.wp.generalSettings.siteUrl
+        // },
+        // serialize: ({ site, allSitePage }) =>
+        //   allSitePage.nodes.map(node => {
+        //     return {
+        //       url: `${site.wp.generalSettings.siteUrl}${node.path}`,
+        //       changefreq: `daily`,
+        //       priority: 0.7,
+        //     }
+        //   })
       }
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -133,39 +133,48 @@ module.exports = {
     {
       resolve: `gatsby-plugin-sitemap`,
       options: {
-        output: `/sitemap.xml`
-        //   query: `
-        //   {
-        //     wp {
-        //       generalSettings {
-        //         siteUrl
-        //       }
-        //     }
+        output: `/sitemap.xml`,
+        query: `
+          {
+            site {
+              siteMetadata {
+                siteUrl
+              }
+            }
 
-        // {
-        //   pages: allPage(filter: {exclude_from_sitemap: {ne: true}, published: {eq: true}}) {
-        //     edges {
-        //       node {
-        //         title
-        //         slugPath
-        //       }
-        //     }
-        //   }
-        // }
+            allSitePage {
+              edges {
+                node {
+                  path
+                }
+              }
+            }
 
-        // }`,
-        // resolveSiteUrl: ({site, allSitePage}) => {
-        //   //Alternatively, you may also pass in an environment variable (or any location) at the beginning of your `gatsby-config.js`.
-        //   return site.wp.generalSettings.siteUrl
-        // },
-        // serialize: ({ site, allSitePage }) =>
-        //   allSitePage.nodes.map(node => {
-        //     return {
-        //       url: `${site.wp.generalSettings.siteUrl}${node.path}`,
-        //       changefreq: `daily`,
-        //       priority: 0.7,
-        //     }
-        //   })
+            excludedPages: allPage(filter: {exclude_from_sitemap: {eq: true}, published: {eq: true}}) {
+              edges {
+                node {
+                  pagePath
+                }
+              }
+            }
+          }
+        `,
+        serialize: ({ site, excludedPages, allSitePage }) => {
+          // Get the paths of all pages that should be excluded from the
+          // sitemap.
+          const excludePaths = excludedPages.edges.map(({ node }) => node.pagePath)
+          // Return an array of any static route Gatsby built, except those that
+          // were excluded.
+          return allSitePage.edges
+            .filter(({ node }) => !excludePaths.includes(node.path))
+            .map(({ node }) => {
+              return {
+                url: `${site.siteMetadata.siteUrl}${node.path}`,
+                changefreq: `daily`,
+                priority: 0.7
+              }
+            })
+        }
       }
     },
     {

--- a/schema.yml
+++ b/schema.yml
@@ -51,7 +51,9 @@
 - type: Page
   node: true
   fields:
+    exclude_from_sitemap: Boolean
     layout: String
+    published: Boolean
     seo: SeoMeta
     title: String
     layout_basic: BasicPage

--- a/src/content/pages/404.md
+++ b/src/content/pages/404.md
@@ -2,6 +2,7 @@
 title: 404 Page Not Found
 model: Page
 published: true
+exclude_from_sitemap: true
 seo:
   title: ''
   description: ''


### PR DESCRIPTION
Adds a field to the page model to be able to exclude from the sitemap, and puts the corresponding logic in place for gatsby-plugin-sitemap.