### PR TITLE
[Fixes #220] Pass URL directly to generated pages for SEO values

### DIFF
--- a/plugins/gatsby-ample-generator/lib/templates/template/adapter.js
+++ b/plugins/gatsby-ample-generator/lib/templates/template/adapter.js
@@ -8,11 +8,11 @@ import SEO from "@src/components/seo"
 
 import Template from "./template"
 
-const TemplateAdapter = ({ data, location }) => {
+const TemplateAdapter = ({ data, pageContext }) => {
   let { page } = data
 
   const seo = normalizeSEO({
-    location: location,
+    url: pageContext.url,
     overrides: page.seo,
     page: { title: page.title }
   })
@@ -32,9 +32,11 @@ TemplateAdapter.propTypes = {
     page: PropTypes.object
   }).isRequired,
   /**
-   * Location object send from the template's source.
+   * The URL at which the page is rendered must be sent.
    */
-  location: PropTypes.object.isRequired
+  pageContext: PropTypes.shape({
+    url: PropTypes.string.isRequired
+  }).isRequired
 }
 
 TemplateAdapter.defaultProps = {}

--- a/plugins/gatsby-ample-pages/gatsby-node.js
+++ b/plugins/gatsby-ample-pages/gatsby-node.js
@@ -4,6 +4,11 @@ const getPagePath = require("./lib/get-page-path")
 exports.createPages = ({ graphql, actions }) => {
   return graphql(`
     {
+      site {
+        siteMetadata {
+          siteUrl
+        }
+      }
       pages: allPage {
         edges {
           node {
@@ -23,12 +28,12 @@ exports.createPages = ({ graphql, actions }) => {
     }
     // Loop through each of the remaining pages and create them.
     pages.map(page => {
+      const pagePath = getPagePath(page, pages)
+
       actions.createPage({
-        path: getPagePath(page, pages),
+        path: pagePath,
         component: path.join(__dirname, "./src/templates/page/adapter.js"),
-        context: {
-          id: page.id
-        }
+        context: { id: page.id, url: `${result.data.site.siteMetadata.siteUrl}${pagePath}` }
       })
     })
   })

--- a/plugins/gatsby-ample-pages/src/templates/page/adapter.js
+++ b/plugins/gatsby-ample-pages/src/templates/page/adapter.js
@@ -7,14 +7,14 @@ import { normalizeSEO, SEO } from "@plugins/gatsby-ample-seo"
 
 import { layouts as pageLayouts } from "@src/templates/page"
 
-const PageAdapter = ({ data, location }) => {
+const PageAdapter = ({ data, pageContext }) => {
   // Extract the page data from the GraphQL query's response.
   let { page } = data
 
   // Normalize the SEO for the SEO component. (Our goal is to refactor this
   // component so that this process happens automatically.)
   const seo = normalizeSEO({
-    location: location,
+    url: pageContext.url,
     overrides: page.seo,
     page: { title: page.title }
   })
@@ -54,11 +54,10 @@ PageAdapter.propTypes = {
     page: PropTypes.object.isRequired
   }).isRequired,
   /**
-   * Location object, sent from gatsby-node.js
+   * The URL at which the page is rendered must be sent.
    */
-  location: PropTypes.shape({
-    href: PropTypes.string.isRequired,
-    origin: PropTypes.string.isRequired
+  pageContext: PropTypes.shape({
+    url: PropTypes.string.isRequired
   }).isRequired
 }
 

--- a/plugins/gatsby-ample-seo/src/helpers/normalize-seo/README.md
+++ b/plugins/gatsby-ample-seo/src/helpers/normalize-seo/README.md
@@ -1,6 +1,6 @@
 # Normalize SEO
 
-The `normalizeSEO` function provides a means for template adapters to pull together dynamic data, combine it with the current location object, and use it to build an object that can be passed on to the [SEO utility](/?path=/docs/utilities-seo--page).
+The `normalizeSEO` function provides a means for template adapters to pull together dynamic data and use it to build an object that can be passed on to the SEO utility.
 
 ## Usage
 
@@ -8,7 +8,7 @@ The function can be imported from the helper's main index file.
 
 It accepts three named objects as arguments:
 
-- `location`: The page's `location` object. This comes from Gatsby as a prop to any static or dynamically-rendered page.
+- `url`: The page's full URL. We typically send this through the `pageContext` object when using the `createPage` node API.
 - `page`: The current page's basic information, including `title`, `description`, and `image`.
 - `overrides`: Optional structured content that can be used to override the page's basic information.
 
@@ -20,10 +20,7 @@ Putting it all together looks something like this:
 import { normalizeSEO } from "../../helpers" // adjust relative to current file
 
 normalizeSEO({
-  location: {
-    origin: '',
-    href: ''
-  },
+  url: '',
   overrides: {
     title: '',
     description: '',

--- a/plugins/gatsby-ample-seo/src/helpers/normalize-seo/index.js
+++ b/plugins/gatsby-ample-seo/src/helpers/normalize-seo/index.js
@@ -28,12 +28,12 @@ const getImageUrl = (baseUrl, image) => {
   return imageUrl.concat(imagePath)
 }
 
-const normalizeSEO = ({ location = {}, overrides = {}, page = {} }) => {
-  let baseUrl = location.origin
-  if (!baseUrl) return {}
+const normalizeSEO = ({ overrides = {}, page = {}, url }) => {
+  if (!url) return {}
+  let baseUrl = new URL(url).origin
 
   // Add URL to the overrides object and store as a new object.
-  let props = { ...page, ...overrides, baseUrl, url: location.href }
+  let props = { ...page, ...overrides, baseUrl, url }
 
   // Add title and image to props if they exist and the overrides don't.
   if (!props.title && page.title) props.title = page.title

--- a/plugins/gatsby-ample-seo/src/helpers/normalize-seo/test.spec.js
+++ b/plugins/gatsby-ample-seo/src/helpers/normalize-seo/test.spec.js
@@ -2,11 +2,8 @@ import { normalizeSEO, getImageUrl, imagePathFromSrc } from "./"
 
 const mockBaseUrl = "https://www.example.com"
 
-const mockLocObj = {
-  location: {
-    href: `${mockBaseUrl}/hello-world`,
-    origin: mockBaseUrl
-  }
+const mockUrl = {
+  url: `${mockBaseUrl}/hello-world`
 }
 
 const mockFluidImg = { childImageSharp: { fluid: { src: "hello-world.jpg" } } }
@@ -61,61 +58,73 @@ describe("normalizeSEO", () => {
   it("returns an empty object unless there's a baseUrl", () => {
     const obj1 = { page: { title: "Hello World" } }
     expect(normalizeSEO(obj1)).toEqual({})
-    const obj2 = { ...mockLocObj, page: { title: "Hello World" } }
+    const obj2 = { ...mockUrl, page: { title: "Hello World" } }
     expect(normalizeSEO(obj2).title).toEqual("Hello World")
   })
-  it("adds location.href as the url prop, adding the origin to it", () => {
-    let obj = { ...mockLocObj }
-    expect(normalizeSEO(obj).url).toEqual("https://www.example.com/hello-world")
+  it("includes the url", () => {
+    let obj = { ...mockUrl }
+    expect(normalizeSEO(obj).url).toEqual(mockUrl.url)
   })
   it("returns the baseUrl", () => {
-    let obj = { ...mockLocObj }
-    expect(normalizeSEO(obj).baseUrl).toEqual(obj.location.origin)
+    let obj = { ...mockUrl }
+    expect(normalizeSEO(obj).baseUrl).toEqual(mockBaseUrl)
   })
 
   // ---------------------------------------- | Title
 
   it("adds title to props", () => {
-    let obj = { ...mockLocObj, page: { title: "Hello World" } }
+    let obj = { ...mockUrl, page: { title: "Hello World" } }
     expect(normalizeSEO(obj).title).toEqual("Hello World")
   })
   it("overrides the title", () => {
-    let obj = { ...mockLocObj, overrides: { title: "Hi there!" }, page: { title: "Hello World" } }
+    let obj = { ...mockUrl, overrides: { title: "Hi there!" }, page: { title: "Hello World" } }
     expect(normalizeSEO(obj).title).toEqual("Hi there!")
   })
+  it("does not override the title with an empty string", () => {
+    let obj = { ...mockUrl, overrides: { title: "" }, page: { title: "Hello World" } }
+    expect(normalizeSEO(obj).title).toEqual("Hello World")
+  })
   it("removes empty strings", () => {
-    let obj = { ...mockLocObj, page: { title: "" } }
+    let obj = { ...mockUrl, page: { title: "" } }
     expect(normalizeSEO(obj).title).toEqual(undefined)
   })
 
   // ---------------------------------------- | Description
 
   it("adds description to props", () => {
-    let obj = { ...mockLocObj, page: { description: "Hello World" } }
+    let obj = { ...mockUrl, page: { description: "Hello World" } }
     expect(normalizeSEO(obj).description).toEqual("Hello World")
   })
   it("overrides the description", () => {
     let obj = {
-      ...mockLocObj,
+      ...mockUrl,
       overrides: { description: "Hi there!" },
       page: { description: "Hello World" }
     }
     expect(normalizeSEO(obj).description).toEqual("Hi there!")
   })
+  it("does not override the description with an empty string", () => {
+    let obj = {
+      ...mockUrl,
+      overrides: { description: "" },
+      page: { description: "Hello World" }
+    }
+    expect(normalizeSEO(obj).description).toEqual("Hello World")
+  })
   it("removes empty strings", () => {
-    let obj = { ...mockLocObj, page: { description: "" } }
+    let obj = { ...mockUrl, page: { description: "" } }
     expect(normalizeSEO(obj).description).toEqual(undefined)
   })
 
   // ---------------------------------------- | Image URL
 
   it("adds imageUrl to props, prepending the baseUrl", () => {
-    let obj = { ...mockLocObj, page: { image: "/image.jpg" } }
+    let obj = { ...mockUrl, page: { image: "/image.jpg" } }
     expect(normalizeSEO(obj).imageUrl).toEqual("https://www.example.com/image.jpg")
   })
   it("removes image and image_src from the object", () => {
     let obj = {
-      ...mockLocObj,
+      ...mockUrl,
       overrides: { image: "/image-02.png", image_src: "/image-02.png" },
       page: { image: "/image.jpg" }
     }
@@ -124,22 +133,26 @@ describe("normalizeSEO", () => {
   })
   it("overrides the image, still prepending the baseUrl", () => {
     let obj = {
-      ...mockLocObj,
+      ...mockUrl,
       overrides: { image: "/image-02.png" },
       page: { image: "/image.jpg" }
     }
     expect(normalizeSEO(obj).imageUrl).toEqual("https://www.example.com/image-02.png")
   })
+  it("does not override the image with an empty string", () => {
+    let obj = { ...mockUrl, overrides: { image: "" }, page: { image: "/image.jpg" } }
+    expect(normalizeSEO(obj).imageUrl).toEqual("https://www.example.com/image.jpg")
+  })
   it("extracts an image URL from a childImageSharp object", () => {
-    let obj = { ...mockLocObj, page: { image: mockFluidImg } }
+    let obj = { ...mockUrl, page: { image: mockFluidImg } }
     expect(normalizeSEO(obj).imageUrl).toEqual("https://www.example.com/hello-world.jpg")
   })
   it("does not extract images properly when it is an object with the wrong keys", () => {
-    let obj = { ...mockLocObj, page: { image: mockFixedImg } }
+    let obj = { ...mockUrl, page: { image: mockFixedImg } }
     expect(normalizeSEO(obj).imageUrl).toEqual(undefined)
   })
   it("does not extract images properly when it is an object with the wrong keys", () => {
-    let obj = { ...mockLocObj, page: { image: mockFixedImg } }
+    let obj = { ...mockUrl, page: { image: mockFixedImg } }
     expect(normalizeSEO(obj).imageUrl).toEqual(undefined)
   })
 
@@ -147,18 +160,18 @@ describe("normalizeSEO", () => {
 
   it("passes OG title and description through", () => {
     let obj = {
-      ...mockLocObj,
+      ...mockUrl,
       overrides: { og: { title: "OG Title", description: "OG Desc ..." } }
     }
     expect(normalizeSEO(obj).og).toEqual(obj.overrides.og)
   })
   it("adds imageUrl to OG props, prepending the baseUrl", () => {
-    let obj = { ...mockLocObj, overrides: { og: { image: "/og-image.jpg" } } }
+    let obj = { ...mockUrl, overrides: { og: { image: "/og-image.jpg" } } }
     expect(normalizeSEO(obj).og.imageUrl).toEqual("https://www.example.com/og-image.jpg")
   })
   it("removes image and image_src from the OG object", () => {
     let obj = {
-      ...mockLocObj,
+      ...mockUrl,
       overrides: { og: { image: "/og-image.jpg", image_src: "/og-image.jpg" } }
     }
     expect(normalizeSEO(obj).og.image).toEqual(undefined)
@@ -169,18 +182,18 @@ describe("normalizeSEO", () => {
 
   it("passes Twitter title and description through", () => {
     let obj = {
-      ...mockLocObj,
+      ...mockUrl,
       overrides: { twitter: { title: "Twitter Title", description: "Twitter Desc ..." } }
     }
     expect(normalizeSEO(obj).twitter).toEqual(obj.overrides.twitter)
   })
   it("adds imageUrl to Twitter props, prepending the baseUrl", () => {
-    let obj = { ...mockLocObj, overrides: { twitter: { image: "/twitter-image.jpg" } } }
+    let obj = { ...mockUrl, overrides: { twitter: { image: "/twitter-image.jpg" } } }
     expect(normalizeSEO(obj).twitter.imageUrl).toEqual("https://www.example.com/twitter-image.jpg")
   })
   it("removes image and image_src from the Twitter object", () => {
     let obj = {
-      ...mockLocObj,
+      ...mockUrl,
       overrides: { twitter: { image: "/twitter-image.jpg", image_src: "/twitter-image.jpg" } }
     }
     expect(normalizeSEO(obj).twitter.image).toEqual(undefined)


### PR DESCRIPTION
## Task

See #220.

## Solution

Instead of relying on the `window.location` object to generate base URL values, pass the URL value to the `nomalizeSEO` utility directly. That means those values will be present at build time and will resolve this issue.