### PR TITLE
[Fixes #228] Add legal pages

### DIFF
--- a/.forestry/front_matter/templates/template-page.yml
+++ b/.forestry/front_matter/templates/template-page.yml
@@ -37,9 +37,9 @@ fields:
     - flexible
     source:
       type: simple
-      section: 
-      file: 
-      path: 
+      section:
+      file:
+      path:
   label: Layout
   description: The layout affects how the page appears on the website, along with
     the fields visible here.
@@ -82,8 +82,13 @@ fields:
   description: While there are sensible defaults, the SEO section provides the option
     to explicitly set meta tag values.
 pages:
+- src/content/pages/404.md
 - src/content/pages/careers.md
 - src/content/pages/contact.md
 - src/content/pages/content-page.md
+- src/content/pages/content-page/nested-page.md
+- src/content/pages/draft-page.md
 - src/content/pages/flexible-page-columns.md
 - src/content/pages/index.md
+- src/content/pages/privacy-policy.md
+- src/content/pages/terms.md

--- a/src/content/admin/footer.md
+++ b/src/content/admin/footer.md
@@ -31,9 +31,9 @@ social_links:
   url: /
 policy_links:
 - label: Terms & Conditions
-  url: "/"
+  url: "/terms"
 - label: Privacy Policy
-  url: "/"
+  url: "/privacy-policy"
 copyright: 2020, All Rights Reserved
 
 ---

--- a/src/content/pages/privacy-policy.md
+++ b/src/content/pages/privacy-policy.md
@@ -1,0 +1,42 @@
+---
+title: Privacy Policy
+model: Page
+published: true
+exclude_from_sitemap: true
+seo:
+  title: ''
+  description: ''
+  image_src: ''
+  og:
+    title: ''
+    description: ''
+    image_src: ''
+  twitter:
+    card: ''
+    title: ''
+    description: ''
+    image_src: ''
+layout: basic
+layout_basic:
+  heading: Privacy Policy
+  body_md: |-
+    Your privacy is important to us. It is Ample's policy to respect your privacy regarding any information we may collect from you across our website, [https://gatsby-starter-ample.netlify.com/](https://gatsby-starter-ample.netlify.com/), and other sites we own and operate.
+
+    We only ask for personal information when we truly need it to provide a service to you. We collect it by fair and lawful means, with your knowledge and consent. We also let you know why we’re collecting it and how it will be used.
+
+    We only retain collected information for as long as necessary to provide you with your requested service. What data we store, we’ll protect within commercially acceptable means to prevent loss and theft, as well as unauthorized access, disclosure, copying, use or modification.
+
+    We don’t share any personally identifying information publicly or with third-parties, except when required to by law.
+
+    Our website may link to external sites that are not operated by us. Please be aware that we have no control over the content and practices of these sites, and cannot accept responsibility or liability for their respective privacy policies.
+
+    You are free to refuse our request for your personal information, with the understanding that we may be unable to provide you with some of your desired services.
+
+    Your continued use of our website will be regarded as acceptance of our practices around privacy and personal information. If you have any questions about how we handle user data and personal information, feel free to contact us.
+
+    This policy is effective as of 1 January 2021.
+
+    [Privacy Policy created with GetTerms.](https://getterms.io "Generate a free privacy policy")
+
+
+---

--- a/src/content/pages/terms.md
+++ b/src/content/pages/terms.md
@@ -1,0 +1,65 @@
+---
+title: Terms & Conditions
+model: Page
+published: true
+exclude_from_sitemap: true
+seo:
+  title: ''
+  description: ''
+  image_src: ''
+  og:
+    title: ''
+    description: ''
+    image_src: ''
+  twitter:
+    card: ''
+    title: ''
+    description: ''
+    image_src: ''
+layout: basic
+layout_basic:
+  heading: Ample Terms of Service
+  body_md: |-
+    ## 1\. Terms
+
+    By accessing the website at [https://gatsby-starter-ample.netlify.com/](https://gatsby-starter-ample.netlify.com/), you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.
+
+    ## 2\. Use License
+
+    1.  Permission is granted to temporarily download one copy of the materials (information or software) on Ample's website for personal, non-commercial transitory viewing only. This is the grant of a license, not a transfer of title, and under this license you may not:
+        1.  modify or copy the materials;
+        2.  use the materials for any commercial purpose, or for any public display (commercial or non-commercial);
+        3.  attempt to decompile or reverse engineer any software contained on Ample's website;
+        4.  remove any copyright or other proprietary notations from the materials; or
+        5.  transfer the materials to another person or "mirror" the materials on any other server.
+    2.  This license shall automatically terminate if you violate any of these restrictions and may be terminated by Ample at any time. Upon terminating your viewing of these materials or upon the termination of this license, you must destroy any downloaded materials in your possession whether in electronic or printed format.
+
+    ## 3\. Disclaimer
+
+    1.  The materials on Ample's website are provided on an 'as is' basis. Ample makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties including, without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights.
+    2.  Further, Ample does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its website or otherwise relating to such materials or on any sites linked to this site.
+
+    ## 4\. Limitations
+
+    In no event shall Ample or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption) arising out of the use or inability to use the materials on Ample's website, even if Ample or a Ample authorized representative has been notified orally or in writing of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.
+
+    ## 5\. Accuracy of materials
+
+    The materials appearing on Ample's website could include technical, typographical, or photographic errors. Ample does not warrant that any of the materials on its website are accurate, complete or current. Ample may make changes to the materials contained on its website at any time without notice. However Ample does not make any commitment to update the materials.
+
+    ## 6\. Links
+
+    Ample has not reviewed all of the sites linked to its website and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by Ample of the site. Use of any such linked website is at the user's own risk.
+
+    ## 7\. Modifications
+
+    Ample may revise these terms of service for its website at any time without notice. By using this website you are agreeing to be bound by the then current version of these terms of service.
+
+    ## 8\. Governing Law
+
+    These terms and conditions are governed by and construed in accordance with the laws of Ohio and you irrevocably submit to the exclusive jurisdiction of the courts in that State or location.
+
+    [Terms of Use created with GetTerms.](https://getterms.io "Generate a free terms of use document")
+
+
+---


### PR DESCRIPTION
Adds privacy policy and terms pages with content [generated by GetTerms](https://getterms.io/g?url=https%3A%2F%2Fgatsby-starter-ample.netlify.com%2F&name=Ample&location=Ohio&effective_date=1+January+2021&language=en-us).

Also updates the pages cache reference for the Forestry template.